### PR TITLE
Give making animation run only when visible a go

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-keyframes": "^0.2.3",
+    "react-on-screen": "^2.0.1",
     "react-transition-group": "^2.2.1",
     "shrink-ray-current": "^2.1.0",
     "styled-components": "^3.1.5",

--- a/pages/features/build-agent-start.js
+++ b/pages/features/build-agent-start.js
@@ -1,6 +1,8 @@
+import styled from 'styled-components'
 import { Keyframes, Frame } from 'react-keyframes'
+import RawTrackVisibility from 'react-on-screen'
 
-import SVGConsoleImage from 'components/SVGConsoleImage'
+import RawSVGConsoleImage from 'components/SVGConsoleImage'
 
 const TEXT_FRAGMENTS = [
   {
@@ -51,13 +53,27 @@ const TEXT_FRAGMENTS = [
   }
 ]
 
-export default ({ ...props }) => (
-  <Keyframes
-    component={SVGConsoleImage}
+const TrackVisibility = styled(RawTrackVisibility)`
+  height: 100%;
+`
+
+const SVGConsoleImageThatOnlyRendersWhenVisible = ({ children, ...props }) => (
+  <RawSVGConsoleImage
     {...props}
     name="buildAgentStart"
     width="547"
     height="260"
+  >
+    <TrackVisibility once>
+      {({ isVisible }) => isVisible && children}
+    </TrackVisibility>
+  </RawSVGConsoleImage>
+)
+
+export default ({ ...props }) => (
+  <Keyframes
+    component={SVGConsoleImageThatOnlyRendersWhenVisible}
+    {...props}
   >
     {TEXT_FRAGMENTS.map(({ duration }, index) => (
       // We concatenate each frame of children to build each subsequent frame,

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,9 +68,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@babel/types@7.0.0-beta.38":
-  version "7.0.0-beta.38"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.38.tgz#2ce2443f7dc6ad535a67db4940cbd34e64035a6f"
+"@babel/types@7.0.0-beta.39":
+  version "7.0.0-beta.39"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.39.tgz#2ea0d97efe4781688751edc68cde640d6559938c"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.2.0"
@@ -4265,6 +4265,10 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+
 lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -5468,6 +5472,13 @@ react-hot-loader@3.1.1:
 react-keyframes@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/react-keyframes/-/react-keyframes-0.2.3.tgz#1dca7e5684b36718f8080c7cf9bf24ce750b1b38"
+
+react-on-screen@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-on-screen/-/react-on-screen-2.0.1.tgz#48c6f5fa823c4e02064417e5b9fa775c36d08b43"
+  dependencies:
+    lodash.throttle "^4.1.1"
+    prop-types "^15.6.0"
 
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"


### PR DESCRIPTION
I couldn’t get this to work - the animation starts as soon as the page loads anyway. Part of the issue is that `react-on-screen` always renders a `div` and that changes the positioning properties of the things inside it, meaning wrapping the SVG in it breaks stuff. Damn.