### PR TITLE
Fix the Getting Started image width on mobile

### DIFF
--- a/components/sections/GetStarted.js
+++ b/components/sections/GetStarted.js
@@ -22,7 +22,7 @@ const GetStartedText = TextCell.extend`
 `
 
 const ImageContainer = ResponsiveImageContainer.extend`
-  width: 400px;
+  max-width: 400px;
 `
 
 export default () => (

--- a/pages/index.js
+++ b/pages/index.js
@@ -62,7 +62,7 @@ const LargeParagraph = styled.p`
 `
 
 const Logos = styled.div`
-  margin: ${({ theme }) => theme.innerSpacing.s1} auto;
+  margin: ${({ theme }) => theme.innerSpacing.s2} auto 0 auto;
   max-width: 100%;
   @media (min-width: 580px) {
     max-width: 85%;


### PR DESCRIPTION
At the moment the Getting Started image is causing an overflow on mobile. This fixes it by using `max-width` instead of `width` (which is needed for the two col layout)