### PR TITLE
Adjust screencast image widths and layout

### DIFF
--- a/components/Grid/index.js
+++ b/components/Grid/index.js
@@ -15,6 +15,18 @@ export const Grid = styled.div`
 
     return `repeat(auto-fit, minmax(${columns}, 1fr))`
   }};
+
+  ${({ minWidth }) => {
+    // Support for dropping down to a single column if the max device width is
+    // less than the minWidth value
+    if (minWidth) {
+      return `
+        @media (max-width: ${minWidth}) {
+          grid-template-columns: repeat(1, 1fr)
+        }
+      `
+    }
+  }};
   `
 
 Grid.defaultProps = {

--- a/components/ScreencastLink.js
+++ b/components/ScreencastLink.js
@@ -14,7 +14,6 @@ const ScreencastLink = styled.a`
 
 const ThumbnailImageContainer = ResponsiveImageContainer.extend`
   ${({ theme }) => theme.images.screenshots}
-  width: 400px;
   margin-bottom: ${({ theme }) => theme.innerSpacing.s1};
   background-color: white;
 `

--- a/pages/screencasts/_page.js
+++ b/pages/screencasts/_page.js
@@ -90,7 +90,7 @@ export default function screencastPage(pathname) {
         <VideoContainer width={1920} height={1080}>
           <video
             controls
-            playsinline
+            playsInline
             preload="auto"
             poster={screencast.images.poster}
           >

--- a/pages/screencasts/index.js
+++ b/pages/screencasts/index.js
@@ -20,7 +20,7 @@ export default page((props) => (
     headImage={openGraphImage}
     {...props}
   >
-    <Grid>
+    <Grid columns={2} minWidth="400px">
       {screencasts.map((screencast) => (
         <ScreencastLink
           screencast={screencast}


### PR DESCRIPTION
At the moment the screencast thumbnails are pushing out the viewport on mobile, and the layout on desktop feels a bit weird with only 4 videos. This changes the videos to be a 2x2 on desktop, and then down to a single column on mobile.