### PR TITLE
Security headers

### DIFF
--- a/server.js
+++ b/server.js
@@ -47,6 +47,18 @@ app.prepare()
       next()
     })
 
+    // Add strict transport and content security headers for parity with rails
+    // app and to prevent leakage.
+    server.use(function(req, res, next) {
+      res.header('X-Frame-Options', 'SAMEORIGIN')
+      res.header('X-XSS-Protection', '1; mode=block')
+      res.header('X-Content-Type-Options', 'nosniff')
+      if (!dev) {
+        res.header('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload')
+      }
+      next()
+    })
+
     // Middleware that strips asset hashes from URLs. The hash is added by babel
     // plugin transform-assets in .babelrc
     //

--- a/server.js
+++ b/server.js
@@ -29,8 +29,11 @@ app.prepare()
   .then(() => {
     const server = express()
 
-    // Don't need to report exact versions of things (for security's sake)
+    // Tell express not to add x-powered-by headers so we don't reveal what we're running
     server.disable('x-powered-by')
+
+    // Tell next.js not to add x-powered-by headers so we don't reveal what we're running
+    app.config.poweredByHeader = false
 
     // Compress our responses to browsers
     server.use(shrinkRay())


### PR DESCRIPTION
We're missing our security headers on https://buildkite.com. Most importantly, we're missing HSTS, so our TLS rating is lowered and we've lost some Google juice.

This replicates the same headers we wrap around the Rails app, except Content-Security-Policy which I don't completely understand and isn't super critical.