### PR TITLE
Add exceptions for advisories 565 and 566

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "~~~ 🎁 Downloading fonts"
-./scripts/download-fonts
+if [[ "$BUILDKITE_LABEL" != ":pipeline:" ]]; then
+  echo "~~~ 🎁 Downloading fonts"
+  ./scripts/download-fonts
+fi

--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,3 @@
+{
+  "exceptions": ["https://nodesecurity.io/advisories/565","https://nodesecurity.io/advisories/566"]
+}


### PR DESCRIPTION
Looks like we'll need to update next.js to 5.0.0 to fix some of these medium issues.