### PR TITLE
These pages should Vary by Cookie, too

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-transition-group": "^2.2.1",
     "shrink-ray-current": "^2.1.0",
     "styled-components": "^3.1.5",
-    "styled-transition-group": "^1.0.0-rc.3"
+    "styled-transition-group": "^1.0.0-rc.3",
+    "vary": "~1.1.2"
   },
   "devDependencies": {
     "babel-plugin-transform-flow-strip-types": "^6.22.0",

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const url = require('url')
 const express = require('express')
 const next = require('next')
 const shrinkRay = require('shrink-ray-current')
+const vary = require('vary')
 
 // We use the cookie lib, instead of the normal express cookies middleware,
 // because this is what next-cookies uses. One less thing that could mis-match.
@@ -73,6 +74,7 @@ app.prepare()
     // The homepage should redirect to dashboard for logged in users. Let's not
     // annoy them with marketing content every day.
     server.get('/', (req, res) => {
+      vary(res, 'Cookie')
       if (req.loggedIn) {
         res.redirect(302, '/dashboard')
       }
@@ -83,6 +85,7 @@ app.prepare()
     // people, so they can actually see the marketing site. They can also share
     // this URL on Twitter and it'll redirect any new visitors to /
     server.get('/home', (req, res) => {
+      vary(res, 'Cookie')
       if (req.loggedIn) {
         nextHandler(req, res)
       } else {


### PR DESCRIPTION
I noticed that express and next.js seem to correctly add the Vary header. We've also made the home routes vary based on the contents of the Cookie header, so we should probably also amend the Vary header. This `vary` package, which is what express, next and shrink-wrap are using, seems to make it easy. 

### Before

```
site (master) % curl -I http://localhost:3000
HTTP/1.1 200 OK
X-Powered-By: Next.js 4.2.3
Cache-Control: no-store, must-revalidate
ETag: "5fc8-0+T4LWe/QeTIfptcVZU4x5V1ov4"
Content-Type: text/html
Content-Length: 24520
Vary: Accept-Encoding
Date: Thu, 01 Mar 2018 05:42:30 GMT
Connection: keep-alive

site (master) % curl -I http://localhost:3000/home
HTTP/1.1 302 Found
Location: /
Vary: Accept, Accept-Encoding
Content-Type: text/plain; charset=utf-8
Content-Length: 23
Date: Thu, 01 Mar 2018 05:42:32 GMT
Connection: keep-alive

site (master) % curl -I http://localhost:3000/support
HTTP/1.1 200 OK
X-Powered-By: Next.js 4.2.3
Cache-Control: no-store, must-revalidate
ETag: "55f3-/mPoGs0qQOVdOhKkvW2Draedii0"
Content-Type: text/html
Content-Length: 22003
Vary: Accept-Encoding
Date: Thu, 01 Mar 2018 05:42:35 GMT
Connection: keep-alive
```

### After

```
site (vary-by-cookie*) % curl -I http://localhost:3000
HTTP/1.1 200 OK
Vary: Cookie, Accept-Encoding
X-Powered-By: Next.js 4.2.3
Cache-Control: no-store, must-revalidate
ETag: "5fc8-OaZnBsRNRNs6RfHe7dfM+9iBJug"
Content-Type: text/html
Content-Length: 24520
Date: Thu, 01 Mar 2018 05:39:31 GMT
Connection: keep-alive

site (vary-by-cookie*) % curl -I http://localhost:3000/home
HTTP/1.1 302 Found
Vary: Cookie, Accept, Accept-Encoding
Location: /
Content-Type: text/plain; charset=utf-8
Content-Length: 23
Date: Thu, 01 Mar 2018 05:39:33 GMT
Connection: keep-alive

site (vary-by-cookie*) % curl -I http://localhost:3000/support
HTTP/1.1 200 OK
X-Powered-By: Next.js 4.2.3
Cache-Control: no-store, must-revalidate
ETag: "55f3-rd2KFX64V3LCWt3n8gGee4nLN4c"
Content-Type: text/html
Content-Length: 22003
Vary: Accept-Encoding
Date: Thu, 01 Mar 2018 05:39:41 GMT
Connection: keep-alive
```