### PR TITLE
Allow data: images for Safari video controls

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,7 +53,7 @@ app.prepare()
       res.header('X-Frame-Options', 'SAMEORIGIN')
       res.header('X-XSS-Protection', '1; mode=block')
       res.header('X-Content-Type-Options', 'nosniff')
-      res.header('Content-Security-Policy', "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' 'unsafe-inline' https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; media-src 'self' https://d3lj8s78qytm30.cloudfront.net")
+      res.header('Content-Security-Policy', "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' 'unsafe-inline' data: https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; media-src 'self' https://d3lj8s78qytm30.cloudfront.net")
       res.header('Referrer-Policy', 'origin-when-cross-origin')
       if (!dev) {
         res.header('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload')


### PR DESCRIPTION
#94 broke the `<video>` controls in Safari — this adds `data:` to the list of allowed image hosts so they're shown again.

Before:

![before](https://user-images.githubusercontent.com/153/37441701-d0d67926-2856-11e8-82b7-69511b15a0d3.png)

After:

![after](https://user-images.githubusercontent.com/153/37441707-d6380704-2856-11e8-9f2c-7848acefe6a9.png)