### PR TITLE
Remove use of .extend

### DIFF
--- a/components/ActionGrid/index.js
+++ b/components/ActionGrid/index.js
@@ -34,7 +34,7 @@ const Nav = styled.nav`
   }
 `
 
-const Grid = RawGrid.extend`
+const Grid = styled(RawGrid)`
   grid-template-columns: 1;
 
   @media (min-width: 580px) {

--- a/components/FeatureGrid.js
+++ b/components/FeatureGrid.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 import { Grid, Cell } from 'components/Grid'
 
-export const FeatureGrid = Grid.extend`
+export const FeatureGrid = styled(Grid)`
   margin: ${({ theme }) => theme.innerSpacing.s1} 0;
   grid-template-columns: repeat(2, 1fr);
 
@@ -11,7 +11,7 @@ export const FeatureGrid = Grid.extend`
   }
 `
 
-export const FeatureCell = Cell.extend`
+export const FeatureCell = styled(Cell)`
   background-color: ${({ theme }) => theme.colors.backgrounds.grey};
   padding: ${({ theme }) => theme.innerSpacing.s2};
 `

--- a/components/ResponsiveContainer.js
+++ b/components/ResponsiveContainer.js
@@ -8,7 +8,7 @@ const ResponsiveContainer = styled.span`
   padding-bottom: ${({ width, height }) => height / width * 100}%;
 `
 
-export const ResponsiveImageContainer = ResponsiveContainer.extend`
+export const ResponsiveImageContainer = styled(ResponsiveContainer)`
   > img {
     position: absolute;
     top: 0;
@@ -18,7 +18,7 @@ export const ResponsiveImageContainer = ResponsiveContainer.extend`
   }
 `
 
-export const ResponsiveVideoContainer = ResponsiveContainer.extend`
+export const ResponsiveVideoContainer = styled(ResponsiveContainer)`
   > video {
     position: absolute;
     top: 0;

--- a/components/ScreencastLink.js
+++ b/components/ScreencastLink.js
@@ -12,7 +12,7 @@ const ScreencastLink = styled.a`
   padding: ${({ theme }) => theme.innerSpacing.s1};
 `
 
-const ThumbnailImageContainer = ResponsiveImageContainer.extend`
+const ThumbnailImageContainer = styled(ResponsiveImageContainer)`
   ${({ theme }) => theme.images.screenshots}
   margin-bottom: ${({ theme }) => theme.innerSpacing.s1};
   background-color: white;

--- a/components/sections/GetStarted.js
+++ b/components/sections/GetStarted.js
@@ -14,7 +14,7 @@ const Paragraph = styled.p`
   margin-bottom: ${({ theme }) => theme.innerSpacing.s1};
 `
 
-const GetStartedText = TextCell.extend`
+const GetStartedText = styled(TextCell)`
   text-align: center;
 
   @media (min-width: 600px) {
@@ -22,7 +22,7 @@ const GetStartedText = TextCell.extend`
   }
 `
 
-const ImageContainer = ResponsiveImageContainer.extend`
+const ImageContainer = styled(ResponsiveImageContainer)`
   max-width: 400px;
 `
 

--- a/components/sections/Screencasts.js
+++ b/components/sections/Screencasts.js
@@ -19,7 +19,7 @@ const Paragraph = styled.p`
   text-align: center;
 `
 
-const CenteredButton = Button.withComponent('span').extend`
+const CenteredButton = styled(Button.withComponent('span'))`
   position: absolute;
   top: 50%;
   left: 50%;

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -27,7 +27,7 @@ const SectionHeader = styled.h1`
   text-align: center;
 `
 
-const InlineSectionHeader = SectionHeader.extend`
+const InlineSectionHeader = styled(SectionHeader)`
   margin-top: 0;
   text-align: left;
   margin-bottom: ${({ theme }) => theme.textSpacing.s1};
@@ -45,7 +45,7 @@ const Section = styled.section`
   margin-bottom: ${({ theme }) => theme.outerSpacing.s3};
 `
 
-const PeopleSection = Section.extend`
+const PeopleSection = styled(Section)`
   text-align: center;
 `
 
@@ -59,7 +59,7 @@ const People = styled.div`
   }
 `
 
-const HeadOfficeImageContainer = ResponsiveImageContainer.extend`
+const HeadOfficeImageContainer = styled(ResponsiveImageContainer)`
   max-width: 500px;
 `
 

--- a/pages/brand-assets.js
+++ b/pages/brand-assets.js
@@ -36,7 +36,7 @@ const Section = styled.section`
   }
 `
 
-const MaxWidthSection = Section.extend`
+const MaxWidthSection = styled(Section)`
   @media (min-width: 742px) {
     ${({ theme }) => theme.maxWidthContainer}
     width: 60%;
@@ -53,7 +53,7 @@ const Paragraph = styled.p`
   margin: ${({ theme }) => theme.textSpacing.s1} 0 ${({ theme }) => theme.innerSpacing.s2} 0;
 `
 
-const AssetListContainer = Grid.extend`
+const AssetListContainer = styled(Grid)`
   background-color: ${({ theme }) => theme.colors.backgrounds.grey};
   padding: ${({ theme }) => theme.innerSpacing.s2};
   grid-template-columns: repeat(2, 1fr);
@@ -71,7 +71,7 @@ const AssetList = ({ children }) => (
   </AssetListContainer>
 )
 
-const AssetCell = Cell.extend`
+const AssetCell = styled(Cell)`
   text-align: center;
 `
 

--- a/pages/case-studies/_page.js
+++ b/pages/case-studies/_page.js
@@ -12,13 +12,13 @@ const FlexContainer = styled.div`
   flex-wrap: wrap;
 `
 
-const HeadingContainer = FlexContainer.extend`
+const HeadingContainer = styled(FlexContainer)`
   align-items: center;
   margin-top: ${({ theme }) => theme.outerSpacing.s1};
   margin-bottom: ${({ theme }) => theme.innerSpacing.s1};
 `
 
-const SpacedFlexContainer = FlexContainer.extend`
+const SpacedFlexContainer = styled(FlexContainer)`
   margin: ${({ theme }) => theme.innerSpacing.s1} -${({ theme }) => theme.innerSpacing.s1};
 
   > * {
@@ -30,7 +30,7 @@ const TextCell = styled.div`
   flex: 3 1 280px;
 `
 
-const CaseStudyWords = TextCell.extend`
+const CaseStudyWords = styled(TextCell)`
   color: ${({ theme }) => theme.colors.text.subdued};
 
   > p {
@@ -47,7 +47,7 @@ const ImageCell = styled.div`
   flex: 1 2 150px;
 `
 
-const LogoCell = ImageCell.extend`
+const LogoCell = styled(ImageCell)`
   margin-left: ${({ theme }) => theme.innerSpacing.s2};
   @media (max-width: 620px) {
     margin-top: ${({ theme }) => theme.innerSpacing.s2};
@@ -55,7 +55,7 @@ const LogoCell = ImageCell.extend`
   }
 `
 
-const ResultsCell = ImageCell.extend`
+const ResultsCell = styled(ImageCell)`
   display: grid;
   align-self: flex-start;
   grid-gap: ${({ theme }) => theme.textSpacing.s1};

--- a/pages/enterprise.js
+++ b/pages/enterprise.js
@@ -27,7 +27,7 @@ const SectionHeader = styled.h2`
   text-align: center;
 `
 
-const CaseStudiesHeader = SectionHeader.extend`
+const CaseStudiesHeader = styled(SectionHeader)`
   margin-bottom: 0;
 `
 
@@ -54,7 +54,7 @@ const FeatureGridSectionDescription = styled.p`
   }
 `
 
-const FeatureImageCell = ImageCell.extend`
+const FeatureImageCell = styled(ImageCell)`
   max-width: ${({ maxWidth }) => maxWidth ? maxWidth : '100%'};
 `
 
@@ -75,12 +75,12 @@ const FeatureSection = styled.section`
   }
 `
 
-const FeatureSectionHeader = SectionHeader.extend`
+const FeatureSectionHeader = styled(SectionHeader)`
   text-align: inherit;
   margin-bottom: ${({ theme }) => theme.innerSpacing.s1};
 `
 
-const FeatureSectionTagline = SectionDescription.extend`
+const FeatureSectionTagline = styled(SectionDescription)`
   text-align: inherit;
 `
 

--- a/pages/features/index.js
+++ b/pages/features/index.js
@@ -78,7 +78,7 @@ const Image = styled.img`
   }
 `
 
-const ImageWithBorder = Image.extend`
+const ImageWithBorder = styled(Image)`
   border: 1px solid black;
 `
 
@@ -92,15 +92,15 @@ const Link = styled.a`
   ${({ theme }) => theme.textStyles.hyperlink}
 `
 
-const MediaItem = RawMediaItem.extend`
+const MediaItem = styled(RawMediaItem)`
   align-items: flex-start;
 `
 
-const TextCell = RawTextCell.extend`
+const TextCell = styled(RawTextCell)`
   flex-grow: 2;
 `
 
-const ImageCell = RawImageCell.extend`
+const ImageCell = styled(RawImageCell)`
   flex-grow: 4;
 `
 
@@ -110,7 +110,7 @@ const OtherFeaturesSection = styled.section`
   margin: ${({ theme }) => theme.outerSpacing.s3} 0;
 `
 
-const SVGAnimation = Image.extend`
+const SVGAnimation = styled(Image)`
   height: auto;
 `
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,7 +13,7 @@ import screenshotPath from '../assets/images/home/screenshot.png'
 import logosNarrowPath from '../assets/images/home/homepage-logos-narrow.png'
 import logosWidePath from '../assets/images/home/homepage-logos-wide.png'
 
-const ScreenshotImageContainer = ResponsiveImageContainer.extend`
+const ScreenshotImageContainer = styled(ResponsiveImageContainer)`
   ${({ theme }) => theme.images.screenshots}
   margin-top: ${({ theme }) => theme.innerSpacing.s1};
   margin-bottom: ${({ theme }) => theme.innerSpacing.s1};
@@ -47,12 +47,12 @@ const Section = styled.section`
   margin-bottom: ${({ theme }) => theme.outerSpacing.s2};
 `
 
-const FeaturesSection = Section.extend`
+const FeaturesSection = styled(Section)`
   margin-top: ${({ theme }) => theme.outerSpacing.s1};
   position: relative;
 `
 
-const FeaturesButton = Button.extend`
+const FeaturesButton = styled(Button)`
   position: absolute;
   top: 50%;
   left: 50%;

--- a/pages/screencasts/_page.js
+++ b/pages/screencasts/_page.js
@@ -31,7 +31,7 @@ const ScreencastParagraph = styled.p`
   max-width: 35em;
 `
 
-const VideoContainer = ResponsiveVideoContainer.extend`
+const VideoContainer = styled(ResponsiveVideoContainer)`
   ${({ theme }) => theme.images.screenshots}
   margin: ${({ theme }) => theme.innerSpacing.s2} 0;
 `

--- a/pages/security.js
+++ b/pages/security.js
@@ -42,14 +42,14 @@ const SecurityParagraph = styled.p`
   margin: ${({ theme }) => theme.textSpacing.s1} 0;
 `
 
-const Monospace = SecurityParagraph.extend`
+const Monospace = styled(SecurityParagraph)`
   font-family: SFMono-Regular, Monaco, Menlo, Consolas, Liberation Mono, Courier, monospace;
   white-space: normal;
   word-break: break-all;
   font-size: .9em;
 `.withComponent('pre')
 
-const PGPSection = Section.extend`
+const PGPSection = styled(Section)`
   ${({ theme }) => theme.maxWidthContainer}
   max-width: 560px;
 `


### PR DESCRIPTION
As of styled-components/styled-components#1546 `x.extend` has been deprecated in favour of `styled(x)`. This switches all our uses of `extend` to the new style.