### PR TITLE
Always use pre-built images for testing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,3 @@
-# docker-compose plugin pinned to:
-# https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/commit/v2.4.04c49fa5c3895cecba5ad1fef86fd6e9f
-
 steps:
 
   - name: ":docker:"
@@ -21,6 +18,15 @@ steps:
         build: site
         image-repository: buildkiteci/site
         image-name: "site-build-${BUILDKITE_BUILD_NUMBER}-prod"
+
+  - name: ":docker::chrome:"
+    agents:
+      queue: elastic-builders
+    plugins:
+      docker-compose#v2.5.1:
+        config: docker-compose.integration-tests.yml
+        push:
+          - integration-tests
 
   - wait
 
@@ -52,8 +58,8 @@ steps:
     timeout_in_minutes: 3
     plugins:
       docker-compose#v2.5.1:
-        run: tests-with-site-prebuilt
-        config: docker-compose.integration-tests.yml
+        run: integration-tests
+        config: docker-compose.integration-tests.prod-image.yml
 
   - wait
 
@@ -99,6 +105,6 @@ steps:
     timeout_in_minutes: 3
     plugins:
       docker-compose#v2.5.1:
-        run: production-tests
-        config: docker-compose.integration-tests.yml
+        run: integration-tests-production
+        config: docker-compose.integration-tests.prod-site.yml
     artifact_paths: "integration-tests/screenshots/*.png"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,11 @@ FROM development as test
 # -- Integration tests
 # Has headless chrome and puppeteer, and adds in Mocha so we can run our tests
 # directly inside it
-FROM puppeteer AS integration-tests
-RUN  npm i -g mocha@5
-ENV  PATH="${PATH}:/node_modules/.bin"
+FROM     puppeteer AS integration-tests
+RUN      npm i -g mocha@5
+ENV      PATH="${PATH}:/node_modules/.bin"
+WORKDIR  /tests
+CMD      ["mocha", "--recursive", "--no-timeouts", "."]
 
 # -- Default target
 FROM production

--- a/docker-compose.integration-tests.prod-image.yml
+++ b/docker-compose.integration-tests.prod-image.yml
@@ -1,0 +1,15 @@
+version: '3.4'
+services:
+  integration-tests:
+    image: "buildkiteci/site:site-build-${BUILDKITE_BUILD_NUMBER}-integration-tests"
+    volumes:
+      - "./integration-tests:/tests"
+    environment:
+      - DEBUG
+    links:
+      - site
+
+  site:
+    image: "buildkiteci/site:site-build-${BUILDKITE_BUILD_NUMBER}-prod"
+    expose:
+      - "3000"

--- a/docker-compose.integration-tests.prod-site.yml
+++ b/docker-compose.integration-tests.prod-site.yml
@@ -1,0 +1,9 @@
+version: '3.4'
+services:
+  integration-tests:
+    image: "buildkiteci/site:site-build-${BUILDKITE_BUILD_NUMBER}-integration-tests"
+    volumes:
+      - "./integration-tests:/tests"
+    environment:
+      - DEBUG
+      - "TEST_HOST=https://buildkite.com"

--- a/docker-compose.integration-tests.yml
+++ b/docker-compose.integration-tests.yml
@@ -1,40 +1,8 @@
 version: '3.4'
-services:
 
-  tests:
-    &tests
+services:
+  integration-tests:
     build:
       context: .
       target: integration-tests
-    volumes:
-      - "./integration-tests:/tests"
-    working_dir: /tests
-    command: mocha --recursive --no-timeouts .
-    environment:
-      - DEBUG
-    links:
-      - site
-
-  tests-with-site-prebuilt:
-    << : *tests
-    links:
-      - "prebuilt-site:site"
-
-  production-tests:
-    << : *tests
-    links: []
-    environment:
-      - DEBUG
-      - "TEST_HOST=https://buildkite.com"
-
-  site:
-    build:
-      context: .
-      target: production
-    expose:
-      - "3000"
-
-  prebuilt-site:
-    image: "buildkiteci/site:site-build-${BUILDKITE_BUILD_NUMBER}-prod"
-    expose:
-      - "3000"
+    image: "buildkiteci/site:site-build-${BUILDKITE_BUILD_NUMBER}-integration-tests"


### PR DESCRIPTION
The build has crept up to 5 minutes because it's not using the cached images. This fixes it, so the build is back to 3 minutes, but has the disadvantage that it can't be run locally. To get it working locally, requires some docker-compose Buildkite plugin changes.