### PR TITLE
Add support for iPhone X "safe area"

### DIFF
--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -28,6 +28,8 @@ const Content = styled.div`
   position: relative;
   background-color: white;
   padding: ${({ theme }) => theme.innerSpacing.s1};
+  padding-left: calc(env(safe-area-inset-left) + ${({ theme }) => theme.innerSpacing.s1});
+  padding-right: calc(env(safe-area-inset-right) + ${({ theme }) => theme.innerSpacing.s1});
   display: flex;
   align-items: center;
   line-height: 1;

--- a/components/Header/menu.js
+++ b/components/Header/menu.js
@@ -9,6 +9,8 @@ const Menu = styled.nav`
   width: 100%;
   background-color: rgba(255,255,255,.98);
   padding: ${({ theme }) => theme.innerSpacing.s1};
+  padding-left: calc(env(safe-area-inset-left) + ${({ theme }) => theme.innerSpacing.s1});
+  padding-right: calc(env(safe-area-inset-right) + ${({ theme }) => theme.innerSpacing.s1});
   box-shadow: ${({ theme }) => theme.boxShadows.menuBar};
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 `

--- a/components/Popover/calculate-viewport-offsets.js
+++ b/components/Popover/calculate-viewport-offsets.js
@@ -2,20 +2,47 @@
 
 const { abs, min, max } = Math
 
-// margin (in pixels) to maintain around automatically-positioned dropdowns
-const SCREEN_MARGIN = 10
-
-const combineAxisOffsets = (lowOffset, highOffset) => (
-  abs(min(lowOffset - SCREEN_MARGIN, 0)) - abs(max(highOffset + SCREEN_MARGIN, 0))
-)
-
 type ViewportOffsets = {
   offsetX: number,
   offsetY: number,
   width: number
 };
 
+// margin (in pixels) to maintain around automatically-positioned dropdowns
+const SCREEN_MARGIN = 10
+
+let safeAreaProbeNode: ?HTMLDivElement
+
+const detectSafeArea = () => {
+  if (!safeAreaProbeNode) {
+    safeAreaProbeNode = document.createElement('div')
+    safeAreaProbeNode.setAttribute('style',
+      'padding: constant(safe-area-inset-top) constant(safe-area-inset-right) constant(safe-area-inset-bottom) constant(safe-area-inset-left);' +
+      'padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);' +
+      'position: absolute;' +
+      'opacity: 0;' +
+      'visibility: hidden;'
+    )
+    document.body && document.body.appendChild(safeAreaProbeNode)
+  }
+
+  let { paddingLeft: left, paddingRight: right, paddingTop: top, paddingBottom: bottom } = getComputedStyle(safeAreaProbeNode)
+
+  left = parseFloat(left)
+  right = parseFloat(right)
+  top = parseFloat(top)
+  bottom = parseFloat(bottom)
+
+  return { left, right, top, bottom }
+}
+
+const combineAxisOffsets = (lowOffset, highOffset, computedScreenMargin = SCREEN_MARGIN) => (
+  abs(min(lowOffset - SCREEN_MARGIN, 0)) - abs(max(highOffset + computedScreenMargin, 0))
+)
+
 export default (requestedWidth: number = 250, offsetNode: HTMLElement): ViewportOffsets => {
+  const safeArea = detectSafeArea()
+  const computedScreenMargin = (safeArea.left + safeArea.right) / 2 + SCREEN_MARGIN
   const windowWidth = window.innerWidth
   const { left: offsetNodeLeft, width: offsetNodeWidth, height: offsetNodeHeight } = offsetNode.getBoundingClientRect()
 
@@ -23,7 +50,7 @@ export default (requestedWidth: number = 250, offsetNode: HTMLElement): Viewport
 
   // automatically shrink the popover to fit the screen if the screen is too small
   // this shouldn't be needed often, but seems worth keeping just in case!
-  const width = min(requestedWidth, windowWidth - (SCREEN_MARGIN * 2))
+  const width = min(requestedWidth, windowWidth - (computedScreenMargin * 2))
 
   // if `leftOffset` is < 0, we need to shift the popup to the right
   const leftOffset = offsetNodeCenterX - (width / 2)
@@ -32,7 +59,7 @@ export default (requestedWidth: number = 250, offsetNode: HTMLElement): Viewport
   const rightOffset = offsetNodeCenterX + (width / 2) - windowWidth
 
   // calculate the overall offset required to stay on-screen
-  const offsetX = combineAxisOffsets(leftOffset, rightOffset)
+  const offsetX = combineAxisOffsets(leftOffset, rightOffset, computedScreenMargin)
   const offsetY = offsetNodeHeight
 
   return {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -15,7 +15,7 @@ export default class MyDocument extends Document {
     return (
       <html lang="en-US">
         <Head>
-          <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes, viewport-fit=cover" />
           <meta name="theme-color" content="#00D974" />
         </Head>
         <body>

--- a/theme/index.js
+++ b/theme/index.js
@@ -29,7 +29,9 @@ export const maxWidthContainer = css`
   margin-left: auto;
   margin-right: auto;
   padding-left: ${innerSpacing.s1};
+  padding-left: calc(env(safe-area-inset-left) + ${innerSpacing.s1});
   padding-right: ${innerSpacing.s1};
+  padding-right: calc(env(safe-area-inset-right) + ${innerSpacing.s1});
 `
 
 export const pageContainer = css`


### PR DESCRIPTION
This updates the site’s layout to go edge-to-edge in landscape on current Apple flagship phones:

[screenshots tba]

Also updates calculateViewportOffsets to handle the “safe area” as margins.