### PR TITLE
Revert "Update dependency styled-components to v4.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-keyframes": "0.2.3",
     "react-transition-group": "2.5.0",
     "retire": "2.0.0",
-    "styled-components": "4.0.1",
+    "styled-components": "4.0.0",
     "styled-transition-group": "1.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5724,10 +5724,10 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-styled-components@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.0.1.tgz#a96b0f6a078ec9212371ae9dd97e43de2729d352"
-  integrity sha512-lEBHwKsynQCUYm4ShjXv8OWkdICHYFdCUzp5IetXdR8ClKtjEZtnnpk7XSA7t7UmyWMiSr/fEgSI26+NJvLR3A==
+styled-components@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.0.0.tgz#bd37d79408246302051cd63f52a3539f70aa3197"
+  integrity sha512-+SXoKjaXmApQHjQXNY5pxuRpnabR7vnL6J59Gtcj118ll8gsg9MM8gkjWu6Ahc0NB9kLjh3O9Ho2iun6uLunVA==
   dependencies:
     "@emotion/is-prop-valid" "^0.6.8"
     babel-plugin-styled-components ">= 1"


### PR DESCRIPTION
Reverts buildkite/site#233 

It seems styled-components/styled-components#2109 introduced a `Cannot read property 'lastIndexOf' of undefined` bug in https://github.com/styled-components/styled-components/pull/2109/files#diff-a8c0cf0a4096edcfba7a13acbf049348R76

`selectors[0]` seems to be undefined — my guess is for styles like https://github.com/buildkite/site/blob/7d751cb79196d70b5dd8603b188645cc2b9c56e9/components/Person/index.js#L28