### PR TITLE
Bump to lodash 4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "security": "yarn run nsp && yarn run retire",
     "nsp": "echo '--- :nsp: Checking node vulns' && npx nsp check",
     "retire": "echo '--- :retirejs: Checking front-end vulns' && npx retire"
+  },
+  "resolutions": {
+    "**/lodash": "4.17.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3759,10 +3759,10 @@ lodash.mapvalues@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
   integrity sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=
 
-lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
+lodash@4.17.11, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 log-update@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
`retirejs` is failing due to https://hackerone.com/reports/380873

This moves us to the new version