### PR TITLE
Add a note about max 200 users on Standard plan

### DIFF
--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -206,7 +206,10 @@ export default page((props) => (
               </>
             }
             notes={
-              <p>Pay annually for a 15% discount</p>
+              <>
+                <p>Up to 200 users</p>
+                <p>Pay annually for a 15% discount</p>
+              </>
             }
           />
         }


### PR DESCRIPTION
This makes a note about the upper bound of 200 users on the Standard plan. 