### PR TITLE
Be clearer about password hashing

### DIFF
--- a/pages/security.js
+++ b/pages/security.js
@@ -124,7 +124,7 @@ export default page((props) => (
           </Brick>
           <Brick>
             <SubSectionSubHeader>User Logins</SubSectionSubHeader>
-            <SecurityParagraph>We protect against brute force attacks with rate limiting technology. All sensitive data such as password and API tokens are filtered out of logs and exception trackers. User passwords are one-way encrypted and salted before being stored in our database.</SecurityParagraph>
+            <SecurityParagraph>We protect against brute force attacks with rate limiting technology. All sensitive data such as password and API tokens are filtered out of logs and exception trackers. User passwords are cryptographically hashed and salted before being stored in our database.</SecurityParagraph>
           </Brick>
           <Brick>
             <SubSectionSubHeader>Penetration Testing</SubSectionSubHeader>


### PR DESCRIPTION
Some folks were finding "one-way encryption" confusing, and we want to be clear that we're not using reversible encryption, so let's use "cryptographically hashed".