### PR TITLE
Update CSP to remove 'unsafe-inline'

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -23,31 +23,8 @@ export default class MyDocument extends Document {
             <Main />
           </div>
           <NextScript />
-          {this.renderAnalytics()}
         </body>
       </html>
     )
-  }
-
-  renderAnalytics() {
-    if (!this.props.req.loggedIn) {
-      return (
-        <>
-          <script
-            async
-            src="https://www.google-analytics.com/analytics.js"
-          />
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
-                window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-                ga('create', 'UA-43649972-1', 'auto');
-                ga('send', 'pageview');
-              `
-            }}
-          />
-        </>
-      )
-    }
   }
 }

--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ app.prepare()
         // user images. We've made it explicit, in case other bad things are
         // hosted on that domain, and the plugins page test will start failing
         // if GitHub change avatar host URLs.
-        res.header('Content-Security-Policy', "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: https://avatars0.githubusercontent.com https://avatars1.githubusercontent.com https://avatars2.githubusercontent.com https://avatars3.githubusercontent.com; connect-src 'self'; media-src 'self' https://d3lj8s78qytm30.cloudfront.net")
+        res.header('Content-Security-Policy', "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://avatars0.githubusercontent.com https://avatars1.githubusercontent.com https://avatars2.githubusercontent.com https://avatars3.githubusercontent.com; media-src 'self' https://d3lj8s78qytm30.cloudfront.net")
         res.header('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload')
       }
       next()

--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ app.prepare()
         // user images. We've made it explicit, in case other bad things are
         // hosted on that domain, and the plugins page test will start failing
         // if GitHub change avatar host URLs.
-        res.header('Content-Security-Policy', "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' 'unsafe-inline' data: https://www.google-analytics.com https://avatars0.githubusercontent.com https://avatars1.githubusercontent.com https://avatars2.githubusercontent.com https://avatars3.githubusercontent.com; connect-src 'self' https://www.google-analytics.com; media-src 'self' https://d3lj8s78qytm30.cloudfront.net")
+        res.header('Content-Security-Policy', "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: https://avatars0.githubusercontent.com https://avatars1.githubusercontent.com https://avatars2.githubusercontent.com https://avatars3.githubusercontent.com; connect-src 'self'; media-src 'self' https://d3lj8s78qytm30.cloudfront.net")
         res.header('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload')
       }
       next()


### PR DESCRIPTION
Now we're on Next.js v8 (#301) we can disallow inline script tags!

* Adds a `styles-src` with `style-src 'self' 'unsafe-inline'` because styled-components injects style tags into the page.
* Updates `default-src` to remove `unsafe-inline` — I believe it was there just for styles, but let's remove it from the default.
* Removes `script-src` and `connect-src` altogether, because they're now covered by `default-src`
* Removes Google Analytics altogether

Tested locally with the following:

```
docker build --target production -t buildkite-site-prod . && \
docker run -it --rm -p "3000:3000" buildkite-site-prod && \
open "http://localhost:3000/"
```