### PR TITLE
Update the feedback link on the support page

### DIFF
--- a/pages/support.js
+++ b/pages/support.js
@@ -32,8 +32,8 @@ export default page((props) => (
         imageWidth={466}
         imageAlt="Post-it note"
         description="Let us know about something you’d like added or improved in Buildkite."
-        url="https://github.com/buildkite/feedback/issues"
-        buttonTitle="Create a GitHub Issue"
+        url="https://forum.buildkite.community/c/feature-requests"
+        buttonTitle="Post a Topic"
       />
       <ActionGridItem
         heading="Community Chat"


### PR DESCRIPTION
In #298 we updated the feedback link to go to the forum, instead of the GitHub issues, but we forgot the support page. This updates that link too.