### PR TITLE
Remove link to frontend

### DIFF
--- a/pages/features/index.js
+++ b/pages/features/index.js
@@ -239,7 +239,7 @@ export default page((props) => (
       <MediaItem>
         <TextCell>
           <Description>
-            Buildkite’s <Link href="https://github.com/buildkite/frontend">open-source web interface</Link> allows you to monitor, control and visualize all your pipelines in one place, whilst still having quick access to your own builds.
+            Buildkite’s web interface allows you to monitor, control and visualize all your pipelines in one place, while still having quick access to your own builds.
           </Description>
           <Description>
             You can also <Link external href="/docs/pipelines/permissions">create teams</Link>, ensuring only the people with the correct permissions have access to sensitive pipelines 🕶

--- a/pages/migrate-from/bamboo.js
+++ b/pages/migrate-from/bamboo.js
@@ -111,7 +111,7 @@ export default page((props) => (
       <Brick>
         <Feature
           name="Powerful pipeline support"
-          description="Configure automated and manual pipelines for Dockerized applications, mobile builds, and existing legacy and on-premise environments. Pipelines can run test scripts, perform deployments, pause for manual intervention, and trigger dependent pipelines; all whilst taking advantage of a distributed artifact and key-value store."
+          description="Configure automated and manual pipelines for Dockerized applications, mobile builds, and existing legacy and on-premise environments. Pipelines can run test scripts, perform deployments, pause for manual intervention, and trigger dependent pipelines; all while taking advantage of a distributed artifact and key-value store."
         />
       </Brick>
       <Brick>


### PR DESCRIPTION
Frontend is archived, now we've moved it into the main (private) repo. So this removes the link to the archived repo on GitHub as it'll only be useful for code historians.