### PR TITLE
Include query string in Matomo tracking

### DIFF
--- a/components/Page/index.js
+++ b/components/Page/index.js
@@ -127,7 +127,7 @@ export const BasePage = (props) => (
 
 export default class Page extends React.PureComponent {
   componentDidMount() {
-    trackPageView({ title: this.props.headTitle, url: Router.pathname })
+    trackPageView({ title: this.props.headTitle, url: Router.asPath })
   }
 
   render() {


### PR DESCRIPTION
Otherwise we don't get to track campaigns