### PR TITLE
Remove explicit prefetches

### DIFF
--- a/components/CaseStudyCallout.js
+++ b/components/CaseStudyCallout.js
@@ -74,7 +74,7 @@ export default ({ caseStudy, noMargin }) => (
 
       <Summary>{caseStudy.summaryWords}</Summary>
 
-      <Link href={caseStudy.pathname} prefetch>
+      <Link href={caseStudy.pathname}>
         <Button>
           Read the Case Study
         </Button>

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -60,14 +60,14 @@ const HeaderLinkAnchor = styled.a`
   `}
 `
 
-const HeaderLink = withRouter(({ children, router, href, external, prefetch, left, right, widescreenOnly }) => {
+const HeaderLink = withRouter(({ children, router, href, external, left, right, widescreenOnly }) => {
   // The following should both mark it as active
   // "/case-studies" and "/case-studies"
   // "/case-studies" and "/case-studies/shopify"
   const active = router.pathname === href || router.pathname.indexOf(`${href}/`) === 0
 
   return (
-    <Link prefetch={prefetch} href={href} external={external}>
+    <Link href={href} external={external}>
       <HeaderLinkAnchor
         left={left}
         right={right}
@@ -109,25 +109,25 @@ export default class Header extends React.PureComponent {
         <Content shadow={this.state.showMenu}>
           <LinkContainer left>
             <MenuLink onClick={this.handleMenuLinkClick} />
-            <HeaderLink left prefetch widescreenOnly href="/features">
+            <HeaderLink left widescreenOnly href="/features">
               Features
             </HeaderLink>
-            <HeaderLink left prefetch widescreenOnly href="/screencasts">
+            <HeaderLink left widescreenOnly href="/screencasts">
               Screencasts
             </HeaderLink>
-            <HeaderLink left prefetch widescreenOnly href="/case-studies">
+            <HeaderLink left widescreenOnly href="/case-studies">
               Case Studies
             </HeaderLink>
           </LinkContainer>
           <LogoLink loggedIn={this.props.loggedIn} />
           <LinkContainer right>
-            <HeaderLink right prefetch widescreenOnly href="/pricing">
+            <HeaderLink right widescreenOnly href="/pricing">
               Pricing
             </HeaderLink>
-            <HeaderLink right prefetch widescreenOnly href="/support">
+            <HeaderLink right widescreenOnly href="/support">
               Support
             </HeaderLink>
-            <HeaderLink right prefetch widescreenOnly href="/about">
+            <HeaderLink right widescreenOnly href="/about">
               About
             </HeaderLink>
             {this.renderLoginLinks()}

--- a/components/Header/logo-link.js
+++ b/components/Header/logo-link.js
@@ -72,7 +72,7 @@ const WordMark = styled.img`
 
 export default ({ loggedIn }) => (
   <>
-    <Link prefetch href={loggedIn ? "/home" : "/"}>
+    <Link href={loggedIn ? "/home" : "/"}>
       <LinkTag>
         <Mark src={markSvgPath} alt="Buildkite logo" />
         <WordMark src={wordmarkSvgPath} alt="Buildkite" />

--- a/components/Link.js
+++ b/components/Link.js
@@ -9,7 +9,7 @@ import React, { Children } from 'react'
 // We could probably get away with not having this component if we didn't mix
 // Next and non-Next page requests on buildkite.com
 
-export default ({ href, external, prefetch, children }) => {
+export default ({ href, external, children }) => {
   // This will return the first child, if multiple are provided it will throw an error
   const child = Children.only(children)
 
@@ -21,7 +21,7 @@ export default ({ href, external, prefetch, children }) => {
   // does lots of things for us, including prefetching etc
   return React.createElement(
     Link,
-    { href: href, passHref: true, prefetch: prefetch },
+    { href: href, passHref: true },
     children
   )
 

--- a/components/ScreencastLink.js
+++ b/components/ScreencastLink.js
@@ -34,7 +34,7 @@ const ScreencastDetail = styled.p`
 `
 
 export default ({ screencast, ...props }) => (
-  <Link href={screencast.pathname} prefetch>
+  <Link href={screencast.pathname}>
     <ScreencastLink {...props}>
       <ThumbnailImageContainer width={800} height={450}>
         <img src={screencast.images.thumbnail} alt={screencast.title} />


### PR DESCRIPTION
Fixes the Next.js prefetch warnings, as this is automatically handled by Next.js now:
* https://github.com/zeit/next.js/blob/master/errors/prefetch-true-deprecated.md
* https://nextjs.org/blog/next-9#prefetching-in-viewport-links