### PR TITLE
Update `package.json` resolutions to fix dep vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "resolutions": {
     "**/js-yaml": ">=3.13.0",
-    "**/https-proxy-agent": ">=3.0.0"
+    "**/https-proxy-agent": ">=3.0.0",
+    "**/serialize-javascript": ">=2.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7695,10 +7695,10 @@ send@^0.16.1:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
-serialize-javascript@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
-  integrity sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==
+serialize-javascript@>=2.1.1, serialize-javascript@^1.7.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 serve-static@1.14.1:
   version "1.14.1"


### PR DESCRIPTION
- `serialize-javascript` was found to be vulnerable to XSS, as per https://github.com/yahoo/serialize-javascript/security/advisories/GHSA-h9rv-jmmf-4pgx
- updating the resolution to require at least v2.1.1 fixes it